### PR TITLE
Implement aerial platform: part 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(as2_core REQUIRED)
 find_package(rclcpp REQUIRED)
+
+find_package(ardupilot_msgs REQUIRED)
 find_package(as2_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,39 @@ find_package(std_srvs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 
+if (APPLE)
+  # macOS Sonoma 14.5 aarch64 transitive dependency issue
+  find_package(GeographicLib REQUIRED)
+  find_package(yaml-cpp REQUIRED)
+
+  # assuming yaml-cpp installed with brew
+  if (CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+    link_directories("/opt/homebrew/opt/yaml-cpp/lib")
+  elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    link_directories("/usr/local/opt/yaml-cpp/lib")
+  endif()
+
+endif()
+
+#----------------------------------------------------------------------------
+# build
+
+add_executable(${PROJECT_NAME}_node
+  src/ardupilot_platform_main.cpp
+  src/ardupilot_platform.cpp
+)
+
+target_include_directories(${PROJECT_NAME}_node
+  PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"  
+)
+
+target_link_libraries(${PROJECT_NAME}_node
+  as2_core::as2_core
+  GeographicLib::GeographicLib
+)
+
 #----------------------------------------------------------------------------
 # testing
 
@@ -36,5 +69,20 @@ endif()
 
 #----------------------------------------------------------------------------
 # install
+
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME})
+
+install(DIRECTORY
+  config
+  DESTINATION share/${PROJECT_NAME})
+
+install(TARGETS
+  ${PROJECT_NAME}_node
+  DESTINATION lib/${PROJECT_NAME})
+
+#----------------------------------------------------------------------------
+# ament_package last
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ endif()
 # dependencies
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+
 find_package(as2_core REQUIRED)
 find_package(rclcpp REQUIRED)
 
@@ -72,17 +74,25 @@ endif()
 #----------------------------------------------------------------------------
 # install
 
+# install launch files.
 install(DIRECTORY
   launch
   DESTINATION share/${PROJECT_NAME})
 
+# install config.
 install(DIRECTORY
   config
   DESTINATION share/${PROJECT_NAME})
 
+# install executables.
 install(TARGETS
   ${PROJECT_NAME}_node
   DESTINATION lib/${PROJECT_NAME})
+
+# install Python package.
+  ament_python_install_package(${PROJECT_NAME}
+  PACKAGE_DIR src/${PROJECT_NAME}
+)
 
 #----------------------------------------------------------------------------
 # ament_package last

--- a/config/control_modes.yaml
+++ b/config/control_modes.yaml
@@ -1,0 +1,33 @@
+#----------------------------------------------------------------------------
+# ArduPilot control modes depend on the vehicle type. These are given
+# by the FLTMODEn parameter:
+# https://ardupilot.org/copter/docs/parameters.html#fltmode1-flight-mode-1
+#
+#
+#----------------------------------------------------------------------------
+
+available_modes:
+  - 0  # Stabilize
+  - 1  # Acro
+  - 2  # AltHold
+  - 3  # Auto
+  - 4  # Guided
+  - 5  # Loiter
+  - 7  # Circle
+  - 9  # Land
+  - 11 # Drift
+  - 13 # Sport
+  - 14 # Flip
+  - 15 # AutoTune
+  - 16 # PosHold
+  - 17 # Brake
+  - 18 # Throw
+  - 19 # Avoid_ADSB
+  - 20 # Guided_NoGPS
+  - 21 # SmartRTL
+  - 22 # FlowHold
+  - 23 # Follow
+  - 24 # ZigZag
+  - 25 # SystemID
+  - 26 # HeliAutorotate
+  - 27 # AutoRTL

--- a/config/platform_config_file.yaml
+++ b/config/platform_config_file.yaml
@@ -1,5 +1,5 @@
 /**:
-  ros_parameters:
+  ros__parameters:
     cmd_freq: 100.0  # freq platform publishes commands (Hz)
     info_freq: 10.0  # freq platform publishes info (Hz)
     mass: 1.0  # mass of vehicle (kg)

--- a/config/platform_conflig_file.yaml
+++ b/config/platform_conflig_file.yaml
@@ -1,0 +1,8 @@
+/**:
+  ros_parameters:
+    cmd_freq: 100.0  # freq platform publishes commands (Hz)
+    info_freq: 10.0  # freq platform publishes info (Hz)
+    mass: 1.0  # mass of vehicle (kg)
+    max_thrust: 15.0  # max thrust (N)
+    min_thrust: 0.15  # min thrust (N)
+    external_odom: false  # use an external odometry source

--- a/include/as2_platform_ardupilot/ardupilot_platform.hpp
+++ b/include/as2_platform_ardupilot/ardupilot_platform.hpp
@@ -19,6 +19,7 @@
 #define ARDUPILOT_PLATFORM_HPP_
 
 #include <memory>
+#include <string>
 
 #include <as2_core/aerial_platform.hpp>
 #include <as2_core/node.hpp>
@@ -40,6 +41,7 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include <std_srvs/srv/set_bool.hpp>
+// #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 
 namespace ardupilot_platform
@@ -70,6 +72,9 @@ public:
   // rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_state_sub_;
 
 private:
+  std::string base_link_frame_id_;
+  std::string odom_frame_id_;
+
   // as2_msgs::msg::ControlMode control_in_;
   // double yaw_rate_limit_ = M_PI_2;
 

--- a/include/as2_platform_ardupilot/ardupilot_platform.hpp
+++ b/include/as2_platform_ardupilot/ardupilot_platform.hpp
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2024 ArduPilot.org.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef ARDUPILOT_PLATFORM_HPP_
+#define ARDUPILOT_PLATFORM_HPP_
+
+#include <memory>
+
+#include <as2_core/aerial_platform.hpp>
+#include <as2_core/node.hpp>
+
+#include <rclcpp/publisher.hpp>
+#include <rclcpp/publisher_options.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <as2_msgs/msg/alert_event.hpp>
+#include <as2_msgs/msg/control_mode.hpp>
+#include <as2_msgs/msg/platform_info.hpp>
+#include <as2_msgs/msg/platform_status.hpp>
+#include <as2_msgs/msg/thrust.hpp>
+#include <as2_msgs/msg/trajectory_point.hpp>
+#include <as2_msgs/srv/list_control_modes.hpp>
+#include <as2_msgs/srv/set_control_mode.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <std_msgs/msg/bool.hpp>
+#include <std_srvs/srv/set_bool.hpp>
+
+
+namespace ardupilot_platform
+{
+
+class ArduPilotPlatform : public as2::AerialPlatform
+{
+public:
+  ArduPilotPlatform();
+  virtual ~ArduPilotPlatform();
+
+public:
+  void configureSensors() override;
+  bool ownSendCommand() override;
+  bool ownSetArmingState(bool state) override;
+  bool ownSetOffboardControl(bool offboard) override;
+  bool ownSetPlatformControlMode(const as2_msgs::msg::ControlMode &msg) override;
+  void ownKillSwitch() override;
+  void ownStopPlatform() override;
+  bool ownTakeoff() override;
+  bool ownLand() override;
+
+  // Publishers
+  // rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr twist_pub_;
+  // rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr arm_pub_;
+
+  // Subscribers
+  // rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_state_sub_;
+
+private:
+  // as2_msgs::msg::ControlMode control_in_;
+  // double yaw_rate_limit_ = M_PI_2;
+
+  // bool enable_takeoff_           = false;
+  // bool enable_land_              = false;
+  // bool state_received_           = false;
+  // double current_height_         = 0.0;
+  // double current_vertical_speed_ = 0.0;
+  // std::shared_ptr<as2::tf::TfHandler> tf_handler_;
+
+  // void resetCommandTwistMsg();
+  // void state_callback(const geometry_msgs::msg::TwistStamped::SharedPtr _twist_msg);
+};
+
+} // namespace ardupilot_platform
+
+#endif // ARDUPILOT_PLATFORM_HPP_

--- a/launch/ardupilot.launch.py
+++ b/launch/ardupilot.launch.py
@@ -1,0 +1,33 @@
+# Copyright 2024 ArduPilot.org.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Launch the Aerostack platform for ArduPilot.
+
+Run with default arguments:
+
+ros2 launch as2_platform_ardupilot ardupilot.launch.py
+
+Show launch arguments:
+
+ros2 launch as2_platform_ardupilot ardupilot.launch.py --show-args
+"""
+from launch import LaunchDescription
+from as2_platform_ardupilot.launch import PlatformLaunch
+
+
+def generate_launch_description() -> LaunchDescription:
+    """Generate a launch description for the ArduPilot platform."""
+    return PlatformLaunch.generate_launch_description()

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
   <depend>rclcpp</depend>
 
   <depend>ardupilot_msgs</depend>
+  <depend>ardupilot_sitl</depend>
   <depend>as2_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
   <depend>as2_core</depend>
   <depend>rclcpp</depend>
 
+  <depend>ardupilot_msgs</depend>
   <depend>as2_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>

--- a/src/ardupilot_platform.cpp
+++ b/src/ardupilot_platform.cpp
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2024 ArduPilot.org.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "as2_platform_ardupilot/ardupilot_platform.hpp"
+
+namespace ardupilot_platform
+{
+
+ArduPilotPlatform::ArduPilotPlatform()
+  : as2::AerialPlatform()
+{
+}
+
+ArduPilotPlatform::~ArduPilotPlatform()
+{
+}
+
+void ArduPilotPlatform::configureSensors()
+{
+}
+
+bool ArduPilotPlatform::ownSendCommand()
+{
+  return false;
+}
+
+bool ArduPilotPlatform::ownSetArmingState(bool state)
+{
+  return false;
+}
+
+bool ArduPilotPlatform::ownSetOffboardControl(bool offboard)
+{
+  return false;
+}
+
+bool ArduPilotPlatform::ownSetPlatformControlMode(const as2_msgs::msg::ControlMode &msg)
+{
+  return false;
+}
+
+void ArduPilotPlatform::ownKillSwitch()
+{
+}
+
+void ArduPilotPlatform::ownStopPlatform()
+{
+}
+
+bool ArduPilotPlatform::ownTakeoff()
+{
+  return false;
+}
+
+bool ArduPilotPlatform::ownLand()
+{
+  return false;
+}
+
+} // namespace ardupilot_platform

--- a/src/ardupilot_platform.cpp
+++ b/src/ardupilot_platform.cpp
@@ -17,12 +17,35 @@
 
 #include "as2_platform_ardupilot/ardupilot_platform.hpp"
 
+#include <memory>
+#include <string>
+
+#include <as2_core/utils/tf_utils.hpp>
+
 namespace ardupilot_platform
 {
 
 ArduPilotPlatform::ArduPilotPlatform()
   : as2::AerialPlatform()
 {
+  // dev guide states it is not necessary to call configureSensors, but it
+  // is called in the PX4 platform?
+  // configureSensors();
+
+  // generate frame ids
+  base_link_frame_id_ = as2::tf::generateTfName(this, "base_link");
+  odom_frame_id_ = as2::tf::generateTfName(this, "odom");
+
+  // create static transforms
+
+
+  // create ardupilot_dds subscribers
+
+
+  // create ardupilot_dds publishers
+
+  // 
+
 }
 
 ArduPilotPlatform::~ArduPilotPlatform()
@@ -38,17 +61,17 @@ bool ArduPilotPlatform::ownSendCommand()
   return false;
 }
 
-bool ArduPilotPlatform::ownSetArmingState(bool state)
+bool ArduPilotPlatform::ownSetArmingState(bool /*state*/)
 {
   return false;
 }
 
-bool ArduPilotPlatform::ownSetOffboardControl(bool offboard)
+bool ArduPilotPlatform::ownSetOffboardControl(bool /*offboard*/)
 {
   return false;
 }
 
-bool ArduPilotPlatform::ownSetPlatformControlMode(const as2_msgs::msg::ControlMode &msg)
+bool ArduPilotPlatform::ownSetPlatformControlMode(const as2_msgs::msg::ControlMode &/*msg*/)
 {
   return false;
 }

--- a/src/ardupilot_platform_main.cpp
+++ b/src/ardupilot_platform_main.cpp
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2024 ArduPilot.org.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <as2_core/core_functions.hpp>
+#include <as2_platform_ardupilot/ardupilot_platform.hpp>
+
+int main(int argc, char* argv[])
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<ardupilot_platform::ArduPilotPlatform>();
+  node->preset_loop_frequency(300);
+  as2::spinLoop(node);
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/as2_platform_ardupilot/launch.py
+++ b/src/as2_platform_ardupilot/launch.py
@@ -1,0 +1,131 @@
+# Copyright 2024 ArduPilot.org.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Launch actions for ArduPilot."""
+from typing import List
+from typing import Dict
+from typing import Text
+from typing import Tuple
+
+from launch import LaunchContext
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import EnvironmentVariable
+from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PathJoinSubstitution
+
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+from ardupilot_sitl.actions import ExecuteFunction
+
+
+class PlatformLaunch:
+    """Launch functions for ArduPilot SITL."""
+
+    @staticmethod
+    def generate_action(context: LaunchContext, *args, **kwargs) -> ExecuteProcess:
+        """Return an Aerostack ArduPilot platform process."""
+        # Retrieve launch arguments.
+        namespace = LaunchConfiguration("namespace").perform(context)
+        control_modes = LaunchConfiguration("control_modes_file").perform(context)
+        platform_config = LaunchConfiguration("platform_config_file").perform(context)
+
+        # Display launch arguments.
+        print(f"namespace:        {namespace}")
+        print(f"control_modes:    {control_modes}")
+        print(f"platform_config:  {platform_config}")
+
+        node = Node(
+            package="as2_platform_ardupilot",
+            executable="as2_platform_ardupilot_node",
+            name="platform",
+            namespace=LaunchConfiguration("namespace"),
+            output="screen",
+            emulate_tty=True,
+            parameters=[
+                {
+                    "control_modes_file": control_modes,
+                },
+                platform_config,
+            ],
+        )
+        return node
+
+    @staticmethod
+    def generate_launch_description_with_actions() -> (
+        Tuple[LaunchDescription, Dict[Text, ExecuteFunction]]
+    ):
+        """Generate a launch description for the ArduPilot platform."""
+        launch_arguments = PlatformLaunch.generate_launch_arguments()
+
+        action = ExecuteFunction(function=PlatformLaunch.generate_action)
+
+        ld = LaunchDescription(
+            launch_arguments
+            + [
+                action,
+            ]
+        )
+        actions = {
+            "as2_platform_ardupilot": action,
+        }
+        return ld, actions
+
+    @staticmethod
+    def generate_launch_description() -> LaunchDescription:
+        """Generate a launch description."""
+        ld, _ = PlatformLaunch.generate_launch_description_with_actions()
+        return ld
+
+    @staticmethod
+    def generate_launch_arguments() -> List[DeclareLaunchArgument]:
+        """Generate a list of launch arguments."""
+
+        # Default control modes config file.
+        control_modes = PathJoinSubstitution(
+            [FindPackageShare("as2_platform_ardupilot"), "config", "control_modes.yaml"]
+        )
+
+        # Default platform config file.
+        platform_config_file = PathJoinSubstitution(
+            [
+                FindPackageShare("as2_platform_ardupilot"),
+                "config",
+                "platform_config_file.yaml",
+            ]
+        )
+
+        launch_args = [
+            # Required launch arguments.
+            DeclareLaunchArgument(
+                "namespace",
+                default_value="drone0",
+                description="Vehicle namespace.",
+            ),
+            DeclareLaunchArgument(
+                "control_modes_file",
+                default_value=control_modes,
+                description="Platform control modes file",
+            ),
+            DeclareLaunchArgument(
+                "platform_config_file",
+                default_value=platform_config_file,
+                description="Platform configuration file",
+            ),
+        ]
+
+        return launch_args


### PR DESCRIPTION
Implement the ArduPilot aerial platform - part 1

- Provide stub implementations of the as2::AerialPlatform interface.
- Add a Python module and launch file to bring up the node.
- Install config files for params and the platform.
- Provide control modes for ArduCopter.

The node can be launched with:

```bash
ros2 launch as2_platform_ardupilot ardupilot.launch.py
```

At this stage it will report errors  `[ERROR] [1718112940.167684000] [as2_mode]: Yaw mode not recognized` as the functions to communicate with ArduPilot DDS are not yet implemented. 