### PR TITLE
Implement aerial platform: part 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,15 @@ target_include_directories(${PROJECT_NAME}_node
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"  
 )
 
+ament_target_dependencies(${PROJECT_NAME}_node
+  ardupilot_msgs
+  as2_msgs
+  geometry_msgs
+  sensor_msgs
+  std_msgs
+  std_srvs
+)
+
 target_link_libraries(${PROJECT_NAME}_node
   as2_core::as2_core
   GeographicLib::GeographicLib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,16 +12,17 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 
 find_package(as2_core REQUIRED)
+find_package(message_filters REQUIRED)
 find_package(rclcpp REQUIRED)
 
 find_package(ardupilot_msgs REQUIRED)
 find_package(as2_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
-find_package(nav_msgs REQUIRED)
 
 if (APPLE)
   # macOS Sonoma 14.5 aarch64 transitive dependency issue
@@ -52,9 +53,13 @@ target_include_directories(${PROJECT_NAME}_node
 )
 
 ament_target_dependencies(${PROJECT_NAME}_node
+  as2_core
+  message_filters
+  rclcpp
   ardupilot_msgs
   as2_msgs
   geometry_msgs
+  nav_msgs
   sensor_msgs
   std_msgs
   std_srvs

--- a/config/platform_config_file.yaml
+++ b/config/platform_config_file.yaml
@@ -5,4 +5,5 @@
     mass: 1.0  # mass of vehicle (kg)
     max_thrust: 15.0  # max thrust (N)
     min_thrust: 0.15  # min thrust (N)
-    external_odom: false  # use an external odometry source
+    use_external_odom: false  # use an external odometry source
+

--- a/include/as2_platform_ardupilot/ardupilot_platform.hpp
+++ b/include/as2_platform_ardupilot/ardupilot_platform.hpp
@@ -28,6 +28,9 @@
 #include <rclcpp/publisher_options.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <ardupilot_msgs/msg/global_position.hpp>
+#include <ardupilot_msgs/srv/arm_motors.hpp>
+#include <ardupilot_msgs/srv/mode_switch.hpp>
 #include <as2_msgs/msg/alert_event.hpp>
 #include <as2_msgs/msg/control_mode.hpp>
 #include <as2_msgs/msg/platform_info.hpp>
@@ -38,10 +41,9 @@
 #include <as2_msgs/srv/set_control_mode.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
-#include <nav_msgs/msg/odometry.hpp>
-#include <std_msgs/msg/bool.hpp>
-#include <std_srvs/srv/set_bool.hpp>
-// #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <sensor_msgs/msg/battery_state.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/nav_sat_fix.hpp>
 
 
 namespace ardupilot_platform
@@ -64,13 +66,6 @@ public:
   bool ownTakeoff() override;
   bool ownLand() override;
 
-  // Publishers
-  // rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr twist_pub_;
-  // rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr arm_pub_;
-
-  // Subscribers
-  // rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_state_sub_;
-
 private:
   std::string base_link_frame_id_;
   std::string odom_frame_id_;
@@ -87,6 +82,37 @@ private:
 
   // void resetCommandTwistMsg();
   // void state_callback(const geometry_msgs::msg::TwistStamped::SharedPtr _twist_msg);
+
+  // Ardupilot publishers
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr ap_cmd_vel_pub_;
+  rclcpp::Publisher<ardupilot_msgs::msg::GlobalPosition>::SharedPtr ap_cmd_gps_pose_pub_;
+
+  // Ardupilot subscribers
+  rclcpp::Subscription<sensor_msgs::msg::NavSatFix>::SharedPtr ap_nav_sat_sub_;
+  rclcpp::Subscription<sensor_msgs::msg::BatteryState>::SharedPtr ap_battery_sub_;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr ap_imu_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr ap_pose_filtered_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr ap_twist_filtered_sub_;
+
+  // Ardupilot service clients
+  rclcpp::Client<ardupilot_msgs::srv::ArmMotors>::SharedPtr ap_arm_motors_client_;
+  rclcpp::Client<ardupilot_msgs::srv::ModeSwitch>::SharedPtr ap_mode_switch_client_;
+
+  // ArduPilot functions
+  void apArm();
+  void apDisarm();
+  void apPublishOffboardControlMode();
+  void apPublishTrajectorySetpoint();
+  void apPublishAttitudeSetpoint();
+  void apPublishRatesSetpoint();
+  void apPublishVehicleCommand();
+
+  // ArduPilot callbacks
+  void apNavSatFixCallback(const sensor_msgs::msg::NavSatFix::SharedPtr msg);
+  void apBatteryCallback(const sensor_msgs::msg::BatteryState::SharedPtr msg);
+  void apImuCallback(const sensor_msgs::msg::Imu::SharedPtr msg);
+  void apPoseFilteredCallback(const geometry_msgs::msg::PoseStamped::SharedPtr msg);
+  void apTwistFilteredCallback(const geometry_msgs::msg::TwistStamped::SharedPtr msg);
 };
 
 } // namespace ardupilot_platform

--- a/include/as2_platform_ardupilot/ardupilot_platform.hpp
+++ b/include/as2_platform_ardupilot/ardupilot_platform.hpp
@@ -18,6 +18,7 @@
 #ifndef ARDUPILOT_PLATFORM_HPP_
 #define ARDUPILOT_PLATFORM_HPP_
 
+#include <cmath>
 #include <memory>
 #include <string>
 
@@ -73,10 +74,10 @@ private:
   std::string odom_frame_id_;
 
   // parameters
-  float mass_;
-  float max_thrust_;
-  float min_thrust_;
-  bool use_external_odom_ {true};
+  float mass_ {NAN};
+  float max_thrust_ {NAN};
+  float min_thrust_ {NAN};
+  bool use_external_odom_ {false};
 
   // as2_msgs::msg::ControlMode control_in_;
   // double yaw_rate_limit_ = M_PI_2;

--- a/include/as2_platform_ardupilot/ardupilot_platform.hpp
+++ b/include/as2_platform_ardupilot/ardupilot_platform.hpp
@@ -23,6 +23,7 @@
 
 #include <as2_core/aerial_platform.hpp>
 #include <as2_core/node.hpp>
+#include <as2_core/sensor.hpp>
 
 #include <rclcpp/publisher.hpp>
 #include <rclcpp/publisher_options.hpp>
@@ -67,8 +68,15 @@ public:
   bool ownLand() override;
 
 private:
+  // frame ids
   std::string base_link_frame_id_;
   std::string odom_frame_id_;
+
+  // parameters
+  float mass_;
+  float max_thrust_;
+  float min_thrust_;
+  bool use_external_odom_ {true};
 
   // as2_msgs::msg::ControlMode control_in_;
   // double yaw_rate_limit_ = M_PI_2;
@@ -82,6 +90,14 @@ private:
 
   // void resetCommandTwistMsg();
   // void state_callback(const geometry_msgs::msg::TwistStamped::SharedPtr _twist_msg);
+
+  // Sensors
+  std::unique_ptr<as2::sensors::Barometer> barometer0_;
+  std::unique_ptr<as2::sensors::Battery> battery0_;
+  std::unique_ptr<as2::sensors::Compass> compass0_;
+  std::unique_ptr<as2::sensors::GPS> gps0_;
+  std::unique_ptr<as2::sensors::Imu> imu0_;
+  std::unique_ptr<as2::sensors::Odometry> odometry_filtered_;
 
   // Ardupilot publishers
   rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr ap_cmd_vel_pub_;

--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,7 @@
 
   <depend>ament_cmake</depend>
   <depend>as2_core</depend>
+  <depend>message_filters</depend>
   <depend>rclcpp</depend>
 
   <depend>ardupilot_msgs</depend>

--- a/src/ardupilot_platform.cpp
+++ b/src/ardupilot_platform.cpp
@@ -24,6 +24,8 @@
 #include <as2_core/sensor.hpp>
 #include <as2_core/utils/tf_utils.hpp>
 
+#include <rmw/qos_profiles.h>
+
 using namespace std::chrono_literals;
 
 namespace ardupilot_platform
@@ -79,11 +81,11 @@ ArduPilotPlatform::ArduPilotPlatform()
   // message filters
   ap_pose_filtered_sub_ =
       std::make_unique<message_filters::Subscriber<geometry_msgs::msg::PoseStamped>>(
-          this, "/ap/pose/filtered");
+          this, "/ap/pose/filtered", rmw_qos_profile_sensor_data);
 
   ap_twist_filtered_sub_ =
       std::make_unique<message_filters::Subscriber<geometry_msgs::msg::TwistStamped>>(
-          this, "/ap/twist/filtered");
+          this, "/ap/twist/filtered", rmw_qos_profile_sensor_data);
 
   ap_odom_sync_ = std::make_unique<message_filters::TimeSynchronizer<geometry_msgs::msg::PoseStamped, geometry_msgs::msg::TwistStamped>>(
       *ap_pose_filtered_sub_, *ap_twist_filtered_sub_, 5);
@@ -197,7 +199,6 @@ bool ArduPilotPlatform::ownLand()
   return false;
 }
 
-
 void ArduPilotPlatform::apArm()
 {
   auto request = std::make_shared<ardupilot_msgs::srv::ArmMotors::Request>();
@@ -290,16 +291,19 @@ void ArduPilotPlatform::apPublishVehicleCommand()
 
 void ArduPilotPlatform::apNavSatFixCallback(const sensor_msgs::msg::NavSatFix::ConstSharedPtr msg)
 {
+  // RCLCPP_INFO_STREAM(this->get_logger(), "Received GPS data");
   gps0_->updateData(*msg);
 }
 
 void ArduPilotPlatform::apBatteryCallback(const sensor_msgs::msg::BatteryState::ConstSharedPtr msg)
 {
+  // RCLCPP_INFO_STREAM(this->get_logger(), "Received battery data");
   battery0_->updateData(*msg);
 }
 
 void ArduPilotPlatform::apImuCallback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
 {
+  // RCLCPP_INFO_STREAM(this->get_logger(), "Received IMU data");
   imu0_->updateData(*msg);
 }
 
@@ -307,6 +311,8 @@ void ArduPilotPlatform::apOdomCallback(
     const geometry_msgs::msg::PoseStamped::ConstSharedPtr pose_msg,
     const geometry_msgs::msg::TwistStamped::ConstSharedPtr twist_msg)
 {
+  // RCLCPP_INFO_STREAM(this->get_logger(), "Received odom data");
+
   nav_msgs::msg::Odometry odom_msg;
 
   odom_msg.header.stamp    = pose_msg->header.stamp;

--- a/src/ardupilot_platform.cpp
+++ b/src/ardupilot_platform.cpp
@@ -38,13 +38,40 @@ ArduPilotPlatform::ArduPilotPlatform()
 
   // create static transforms
 
+  // create subscribers
+  ap_nav_sat_sub_ = create_subscription<sensor_msgs::msg::NavSatFix>(
+      "/ap/navsat/navsat0", rclcpp::SensorDataQoS(),
+      std::bind(&ArduPilotPlatform::apNavSatFixCallback, this, std::placeholders::_1));
 
-  // create ardupilot_dds subscribers
+  ap_battery_sub_ = create_subscription<sensor_msgs::msg::BatteryState>(
+      "/ap/battery/battery0", rclcpp::SensorDataQoS(),
+      std::bind(&ArduPilotPlatform::apBatteryCallback, this, std::placeholders::_1));
 
+  ap_imu_sub_ = create_subscription<sensor_msgs::msg::Imu>(
+      "/ap/imu/experimental/data", rclcpp::SensorDataQoS(),
+      std::bind(&ArduPilotPlatform::apImuCallback, this, std::placeholders::_1));
 
-  // create ardupilot_dds publishers
+  ap_pose_filtered_sub_ = create_subscription<geometry_msgs::msg::PoseStamped>(
+      "/ap/pose/filtered", rclcpp::SensorDataQoS(),
+      std::bind(&ArduPilotPlatform::apPoseFilteredCallback, this, std::placeholders::_1));
 
-  // 
+  ap_twist_filtered_sub_ = create_subscription<geometry_msgs::msg::TwistStamped>(
+      "/ap/twist/filtered", rclcpp::SensorDataQoS(),
+      std::bind(&ArduPilotPlatform::apTwistFilteredCallback, this, std::placeholders::_1));
+
+  // create publishers
+  ap_cmd_vel_pub_ = this->create_publisher<geometry_msgs::msg::TwistStamped>(
+    "/ap/cmd_vel", rclcpp::SensorDataQoS());
+
+  ap_cmd_gps_pose_pub_ = this->create_publisher<ardupilot_msgs::msg::GlobalPosition>(
+    "/ap/cmd_vel", rclcpp::SensorDataQoS());
+
+  // create service clients 
+  ap_arm_motors_client_ =
+    create_client<ardupilot_msgs::srv::ArmMotors>("/ap/arm_motors");
+
+  ap_mode_switch_client_ =
+    create_client<ardupilot_msgs::srv::ModeSwitch>("/ap/mode_switch");
 
 }
 
@@ -92,6 +119,63 @@ bool ArduPilotPlatform::ownTakeoff()
 bool ArduPilotPlatform::ownLand()
 {
   return false;
+}
+
+
+void ArduPilotPlatform::apArm()
+{
+  // make the service call
+
+  // wait
+
+  // check status
+
+  RCLCPP_DEBUG(this->get_logger(), "Sent arm command");
+}
+
+void ArduPilotPlatform::apDisarm()
+{
+  RCLCPP_DEBUG(this->get_logger(), "Sent disarm command");
+}
+
+void ArduPilotPlatform::apPublishOffboardControlMode()
+{
+}
+
+void ArduPilotPlatform::apPublishTrajectorySetpoint()
+{
+}
+
+void ArduPilotPlatform::apPublishAttitudeSetpoint()
+{
+}
+
+void ArduPilotPlatform::apPublishRatesSetpoint()
+{
+}
+
+void ArduPilotPlatform::apPublishVehicleCommand()
+{
+}
+
+void ArduPilotPlatform::apNavSatFixCallback(const sensor_msgs::msg::NavSatFix::SharedPtr /*msg*/)
+{
+}
+
+void ArduPilotPlatform::apBatteryCallback(const sensor_msgs::msg::BatteryState::SharedPtr /*msg*/)
+{
+}
+
+void ArduPilotPlatform::apImuCallback(const sensor_msgs::msg::Imu::SharedPtr /*msg*/)
+{
+}
+
+void ArduPilotPlatform::apPoseFilteredCallback(const geometry_msgs::msg::PoseStamped::SharedPtr /*msg*/)
+{
+}
+
+void ArduPilotPlatform::apTwistFilteredCallback(const geometry_msgs::msg::TwistStamped::SharedPtr /*msg*/)
+{
 }
 
 } // namespace ardupilot_platform


### PR DESCRIPTION
Implement the ArduPilot aerial platform - part 2

- Partial implementation of the as2::AerialPlatform interface.
- Add dependency on `message_filters`, used to combine the pose and twist data from ArduPilot for odometry.
- Add publishers, subscribers and services to communicate with the ArduPilot DDS interface.
- Add and configure the aerostack2 sensors.
- Implement platform constructor.
- Implement arm / disarm / mode switch service clients.
- Implement callbacks to populate sensor data and odometry.
